### PR TITLE
Refactor test/build scripts to avoid failures when no publish is needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,11 @@ install:
   - pip install -U platformio
   - pio update
 before_script:
-  - chmod +x ./.travis/check.sh
-  - ./.travis/check.sh
+  - chmod +x ./.travis/test.sh
+  - ./.travis/test.sh
 script:
-  - pio test
-  - pio package pack
-  - pio package publish --non-interactive
+  - chmod +x ./.travis/build.sh
+  - ./.travis/build.sh
 deploy:
   provider: releases
   api_key: $GITHUB_TOKEN

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -23,20 +23,10 @@ LATEST_VERSION=$(echo ${PIO_JSON} | jq '.version.name')
 
 echo "Latest published version is ${LATEST_VERSION}"
 
-echo "Running pre-publish tests..."
-
-pio test -v
-TEST_RESULT=$?
-
-if [[ "${TEST_RESULT}" != "0" ]]; then
-  echo "One or more tests failed. Aborting."
-  exit 1
-fi
-
 if [[ "${LATEST_VERSION}" = "${LIBRARY_VERSION}" ]]; then
   echo "No need to publish!"
-  exit 1
+  exit 0
 fi
 
-echo "Publishing..."
-exit 0
+pio package pack
+pio package publish --non-interactive

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,0 +1,9 @@
+echo "Running pre-publish tests..."
+
+pio test -v
+TEST_RESULT=$?
+
+if [[ "${TEST_RESULT}" != "0" ]]; then
+  echo "One or more tests failed. Aborting."
+  exit 1
+fi


### PR DESCRIPTION
 * Do not exit with status 1 if no publish is needed (so no error shows on Travis build status)
 * Run tests as before_script
 * Run publish as script