### PR TITLE
Delete unused locally defined types

### DIFF
--- a/include/gfx_pixel.hpp
+++ b/include/gfx_pixel.hpp
@@ -1532,19 +1532,15 @@ namespace gfx {
         } else if(is_rgbw::value && PixelTypeLhs::channels<6) {
              // source color model is RGBW
             using tindexR = typename PixelTypeLhs::template channel_index_by_name<channel_name::R>;
-            using tchR = typename PixelTypeLhs::template channel_by_index_unchecked<tindexR::value>;
             const int chiR = tindexR::value;
                 
             using tindexG = typename PixelTypeLhs::template channel_index_by_name<channel_name::G>;
-            using tchG = typename PixelTypeLhs::template channel_by_index_unchecked<tindexG::value>;
             const int chiG = tindexG::value;
 
             using tindexB = typename PixelTypeLhs::template channel_index_by_name<channel_name::B>;
-            using tchB = typename PixelTypeLhs::template channel_by_index_unchecked<tindexB::value>;
             const int chiB = tindexB::value;
 
             using tindexW = typename PixelTypeLhs::template channel_index_by_name<channel_name::W>;
-            using tchW = typename PixelTypeLhs::template channel_by_index_unchecked<tindexW::value>;
             const int chiW = tindexW::value;
             
             if(!is_rhs_rgbw::value && is_rhs_rgb::value && PixelTypeRhs::channels<5) {


### PR DESCRIPTION
Remove four types defined in `gfx_pixel.hpp` which were not used within their local scope. These were resulting in a build error when compiling for ESP32 in ESP-IDF v5.1.2.

```
In file included from lib/htcw_gfx/include/gfx_bitmap.hpp:5,
                 from lib/htcw_gfx/include/gfx_drawing.hpp:7,
                 from lib/htcw_gfx/src/gfx_drawing.cpp:1:
lib/htcw_gfx/include/gfx_pixel.hpp: In function
'constexpr gfx::gfx_result gfx::convert(PixelTypeLhs, PixelTypeRhs*, const PixelTypeRhs*)':
lib/htcw_gfx/include/gfx_pixel.hpp:1939:11: error: typedef
'using tchR = typename PixelTypeLhs::channel_by_index_unchecked<tindexR::value>'
locally defined but not used [-Werror=unused-local-typedefs]
 1939 |     using tchR = typename PixelTypeLhs::template channel_by_index_unchecked<
      |           ^~~~
lib/htcw_gfx/include/gfx_pixel.hpp:1945:11: error: typedef
'using tchG = typename PixelTypeLhs::channel_by_index_unchecked<tindexG::value>'
locally defined but not used [-Werror=unused-local-typedefs]
 1945 |     using tchG = typename PixelTypeLhs::template channel_by_index_unchecked<
      |           ^~~~
lib/htcw_gfx/include/gfx_pixel.hpp:1951:11: error: typedef
'using tchB = typename PixelTypeLhs::channel_by_index_unchecked<tindexB::value>'
locally defined but not used [-Werror=unused-local-typedefs]
 1951 |     using tchB = typename PixelTypeLhs::template channel_by_index_unchecked<
      |           ^~~~
lib/htcw_gfx/include/gfx_pixel.hpp:1957:11: error: typedef
'using tchW = typename PixelTypeLhs::channel_by_index_unchecked<tindexW::value>'
locally defined but not used [-Werror=unused-local-typedefs]
 1957 |     using tchW = typename PixelTypeLhs::template channel_by_index_unchecked<
      |           ^~~~
```