### PR TITLE
Fix build warning for implicit cast from int to bit

### DIFF
--- a/src/gfx_font.cpp
+++ b/src/gfx_font.cpp
@@ -169,13 +169,13 @@ namespace gfx {
         out_font->m_external_leading=order_guard(stream->template read<uint16_t>());
         out_font->m_style = {0,0,0};
         if(0<stream->getch()) {
-            out_font->m_style.italic = 1;
+            out_font->m_style.italic = true;
         }
         if(0<stream->getch()) {
-            out_font->m_style.underline = 1;
+            out_font->m_style.underline = true;
         }
         if(0<stream->getch()) {
-            out_font->m_style.strikeout = 1;
+            out_font->m_style.strikeout = true;
         }
         out_font->m_weight = order_guard(stream->template read<uint16_t>());
         int gc = stream->getch();


### PR DESCRIPTION
Fix the following warnings:

    .pio/libdeps/native/htcw_gfx/src/gfx_font.cpp:178:41: warning:
    implicit truncation from 'int' to a one-bit wide bit-field
    changes value from 1 to -1 [-Wsingle-bit-bitfield-constant-conversion]
                out_font->m_style.strikeout = 1;
                                            ^ ~